### PR TITLE
Update render.py to handle --output-dir arg

### DIFF
--- a/quarto/render.py
+++ b/quarto/render.py
@@ -33,6 +33,9 @@ def render(input,
   if output_file is not None:
     args.extend(["--output", output_file])
   
+  if output_dir is not None:
+    args.extend(["--output-dir", output_dir])
+
   if execute is not None:
     if execute is True:
       args.append("--execute")


### PR DESCRIPTION
Fixed render.py to add the `--output-dir` argument for quarto, following same scheme as for `--output` and `--to`.